### PR TITLE
Wersja 7 - Tricki i bugfixy

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Komendy:
 - `+lookup skill <nazwa skilla>`    - wyszukuje nauczycieli danego skilla lub spella
 - `+lookup spell <nazwa spella>`    - wyszukuje księgi z danym czarem
 - `+lookup spell all`               - pokazuje wszystkie moby z księgami
+- `+lookup trick <nazwa tricka>`    - wyszukuje moba który uczy danego tricka
+- `+lookup trick all`               - pokazuje wszystkie moby uczące tricków
 - `+lookup region <nazwa regionu>`  - dodaje region do listy filtrów
 - `+lookup region <all/clear>`      - czyści filtr regionów
 - `+lookup class <nazwa klasy>`     - dodaje klasę do listy filtrów

--- a/kbase/module.json
+++ b/kbase/module.json
@@ -1,6 +1,6 @@
 {
   "name": "kbase",
-  "version": 6,
+  "version": 7,
   "commands": [ "lookup" ],
   "shortDesc": "Moduł informacji o świecie"
 }

--- a/kbase/spells.json
+++ b/kbase/spells.json
@@ -549,7 +549,8 @@
     "class": "Mag",
     "spells": [
       "Change sex", "Dismiss insect", "Fox Cunning", "hardiness"
-    ]
+    ],
+    "difficulty": 1
   },
   {
     "roomVnum": 10847,
@@ -594,7 +595,7 @@
     "region": "",
     "class": "Mag",
     "spells": [
-      "Fox cunning", "Lightning bolt", "invisbility", "Maze"
+      "Fox cunning", "Lightning bolt", "invisibility", "Maze"
     ],
     "notes": "Wędruje",
     "roaming": "t"
@@ -616,7 +617,8 @@
     "class": "Mag",
     "spells": [
       "Dismiss monster", "Lightning bolt", "lower resistance", "Acid Arrow"
-    ]
+    ],
+    "difficulty": 3
   },
   {
     "roomVnum": 14034,
@@ -626,7 +628,8 @@
     "spells": [
       "vampiric touch", "perfect senses", "hallucinations", "bull strength", "animate dead"
     ],
-    "dangerous": "t"
+    "dangerous": "t",
+    "difficulty": 4
   },
   {
     "roomVnum": 28828,
@@ -639,7 +642,7 @@
     "dangerous": "t"
   },
   {
-    "roomVnum": 45628,
+    "roomVnum": 45550,
     "mob": "Ork Czarodziej",
     "region": "Carrallak",
     "class": "Mag",
@@ -674,7 +677,8 @@
       "Animate Dead", "Ghoul touch", "Embalm", "Ethereal armor"
     ],
     "notes": "Ksiega niewidzialna, dwa chodzą po pustyni",
-    "dangerous": "t"
+    "dangerous": "t",
+    "difficulty": 5
   },
   {
     "roomVnum": 16619,
@@ -693,7 +697,8 @@
     "class": "Mag",
     "spells": [
       "Fly", "force missiles", "confusion shell", "hallucinations"
-    ]
+    ],
+    "difficulty": 5
   },
   {
     "roomVnum": 4519,
@@ -741,7 +746,8 @@
     "class": "Mag",
     "spells": [
       "hold person", "reflect spell I", "Iceshield", "Charm person"
-    ]
+    ],
+    "difficulty": 6
   },
   {
     "roomVnum": 15942,
@@ -772,7 +778,8 @@
     "spells": [
       "Force field", "protection from summon", "antimagic manacles", "hold monster"
     ],
-    "dangerous": "t"
+    "dangerous": "t",
+    "difficulty": 7
   },
   {
     "roomVnum": 9317,
@@ -782,7 +789,8 @@
     "spells": [
       "resist normal weapon", "reflect spell I", "resist elements", "dimension door"
     ],
-    "dangerous": "t"
+    "dangerous": "t",
+    "difficulty": 7
   },
   {
     "roomVnum": 11148,
@@ -793,7 +801,8 @@
       "raise zombie", "iceshield", "decay", "rasie ghoul"
     ],
     "notes": "Niewidzialny",
-    "dangerous": "t"
+    "dangerous": "t",
+    "difficulty": 5
   },
   {
     "roomVnum": 42348,
@@ -814,7 +823,8 @@
       "stone skin", "change staff", "draconic wisdom", "major haste", "giant strength"
     ],
     "dangerous": "t",
-    "boss": "t"
+    "boss": "t",
+    "difficulty": 8
   },
   {
     "roomVnum": 17972,
@@ -852,6 +862,18 @@
     "boss": "t"
   },
   {
+    "roomVnum": 25670,
+    "mob": "Nekromanta Gregzagg",
+    "region": "Forteca",
+    "class": "Mag",
+    "spells": [
+      "raise ghast", "horrid wilting", "power word stun", "unholy fury"
+    ],
+    "dangerous": "t",
+    "boss": "t",
+    "difficulty": 5
+  },
+  {
     "roomVnum": 33068,
     "mob": "Groslug",
     "region": "Arras",
@@ -880,7 +902,8 @@
     "class": "Mag",
     "spells": [
       "force missiles", "acid blast", "hold person", "maze"
-    ]
+    ],
+    "difficulty": 4
   },
   {
     "roomVnum": 1761,
@@ -902,7 +925,8 @@
     "spells": [
       "inspire", "fetch", "loop", "psychic scream", "blink"
     ],
-    "boss": "t"
+    "boss": "t",
+    "difficulty": 10
   },
   {
     "roomVnum": 17965,
@@ -934,7 +958,8 @@
       "unholy fury", "horrid wilthing", "cone of cold", "power word blind", "Mend golem"
     ],
     "dangerous": "t",
-    "boss": "t"
+    "boss": "t",
+    "difficulty": 7
   },
   {
     "roomVnum": 2899,
@@ -1020,7 +1045,8 @@
     "class": "Mag",
     "spells": [
       "Wall of mist", "Flame arrow", "Spirit armor", "hold person"
-    ]
+    ],
+    "notes": "upadły kapłan u duergarów dropi ciemnoszarą księge ze spirit armorem, moze to ta"
   },
   {
     "roomVnum": 5118,
@@ -1029,7 +1055,8 @@
     "class": "Mag",
     "spells": [
       "decay", "minor globe of invulnerability", "raise ghoul", "ghoul touch"
-    ]
+    ],
+    "difficulty": 6
   },
   {
     "roomVnum": 5771,

--- a/kbase/teachers.json
+++ b/kbase/teachers.json
@@ -3493,7 +3493,7 @@
       "szaman"
     ],
 
-    "mob": "Instruktor",
+    "mob": "Drowi Instruktor",
     "region": "Forteca",
     "roomVnum": "27617",
     "skills": [
@@ -3792,7 +3792,7 @@
       "Barbarzyńca",
       "szaman"
     ],
-    "mob": "Uwolniona dusza paladyna",
+    "mob": "Uwolniona dusza starożytnego paladyna",
     "region": "Easterial",
     "skills": [
       {

--- a/kbase/tricks.json
+++ b/kbase/tricks.json
@@ -1,0 +1,246 @@
+[
+  {
+    "name": "Vertical kick",
+    "requirements": [
+      ["kick", 85]
+    ],
+    "mob": "Mnich Keredel",
+    "cost": 5000,
+    "chance": 25,
+    "roomVnum": 1335,
+    "notes": "4,5% przy użyciu skilla kick, max. raz na 7 ticków"
+  },
+  {
+    "name": "Staff Swirl",
+    "requirements": [
+      ["staff", 75],
+      ["twohanded weapon", 75]
+    ],
+    "mob": "Mnich Keredel",
+    "cost": 5250,
+    "chance": 23,
+    "roomVnum": 1335,
+    "notes": "6% na każdą runde walki uzywajac dwuręcznego kija (staff)"
+  },
+  {
+    "name": "Etwine",
+    "requirements": [
+      ["whip", 80]
+    ],
+    "mob": "Drowi instruktor",
+    "cost": 8000 ,
+    "chance": 20,
+    "roomVnum": 27617,
+    "notes": "4,5% na każde trafienie batem (whip)"
+  },
+  {
+    "name": "Weapon Wrench",
+    "requirements": [
+      ["whip mastery", 75],
+      ["disarm ", 75]
+    ],
+    "mob": "Drowi instruktor",
+    "cost": 9000,
+    "chance": 23,
+    "roomVnum": 27617,
+    "notes": "2,5% na przy zwykłym ciosie, 25% na jak ktoś próbuje parowac (parry) kogoś z tym trikiem. \nZamiast whip mastery, możne też być nomadowe weapon mastery."
+  },
+  {
+    "name": "Riposte",
+    "requirements": [
+      ["parry ", 85]
+    ],
+    "mob": "Kapral Ordalys",
+    "cost": 11000,
+    "chance": 19,
+    "roomVnum": 27629,
+    "notes": "5,3% na każde udane parowanie (parry)"
+  },
+  {
+    "name": "Cyclone",
+    "requirements": [
+      ["dualwield style", 85]
+    ],
+    "mob": "Wielki półogr Haghburg",
+    "cost": 7500,
+    "chance": 18,
+    "roomVnum": 6651,
+    "notes": "1,5% na każdą rundę walki walcząc dwoma brońmi"
+  },
+  {
+    "name": "Flabbergast",
+    "requirements": [
+      ["bash", 75]
+    ],
+    "mob": "Zbrojmistrz garnizonu",
+    "cost": 3700,
+    "chance": 12,
+    "roomVnum": 6180,
+    "notes": "9,5% na każde udane powalenie (bash)"
+  },
+  {
+    "name": "Dragon Strike",
+    "requirements": [
+      ["spear", 91],
+      ["twohanded weapon", 91]
+    ],
+    "mob": "Mistrz Moran",
+    "cost": 10000,
+    "chance": 16,
+    "roomVnum": 6455,
+    "notes": "2% na każdą rundę walki używając dwuręcznej włóczni (spear) - zamiast rundy walki uruchamia specjalny atak"
+  },
+  {
+    "name": "Glorious Impale",
+    "requirements": [
+      ["spear", 82],
+      ["twohanded weapon", 82]
+    ],
+    "mob": "Mistrz Moran",
+    "cost": 8188,
+    "chance": 16,
+    "roomVnum": 6455,
+    "notes": "1,6% na każdy trafiony cios dwuręczną włócznią (spear)"
+  },
+  {
+    "name": "Decapitation",
+    "requirements": [
+      ["axe", 91],
+      ["critical strike", 91]
+    ],
+    "mob": "Oprawca",
+    "cost": 6000,
+    "chance": 11,
+    "roomVnum": 28621,
+    "notes": "1% przy udanym trafionym critical strike jakimkolwiek toporem"
+  },
+  {
+    "name": "Thundering Whack",
+    "requirements": [
+      ["stun", 85]
+    ],
+    "mob": "uwolniona dusza starożytnego paladyna",
+    "cost": 7450,
+    "chance": 18,
+    "roomVnum": 10959,
+    "notes": "4% przy jakimkolwiek ogłuszeniu (stun)"
+  },
+  {
+    "name": "Strucking Wallop",
+    "requirements": [
+      ["charge", 85],
+      ["mighty blow", 85]
+    ],
+    "mob": "Stary barbarzyński mistrz",
+    "cost": 7111,
+    "chance": 19,
+    "roomVnum": 17995,
+    "notes": "7,5% przy szarzy wywracajacej"
+  },
+  {
+    "name": "Shove",
+    "requirements": [
+      ["dodge", 75],
+      ["trip", 75]
+    ],
+    "mob": "Pirat Tankartez",
+    "cost": 5900,
+    "chance": 35,
+    "roomVnum": 16628,
+    "notes": "7% przy udanym uniku (dodge)"
+  },
+  {
+    "name": "Thigh Jab",
+    "requirements": [
+      [
+        "dagger",
+        80
+      ]
+    ],
+    "mob": "Pirat Tankartez",
+    "cost": 6666,
+    "chance": 25,
+    "roomVnum": 16628,
+    "notes": "1,8% przy każdym trafieniu sztyletem (dagger)"
+  },
+  {
+    "name": "Bleed (Sword)",
+    "requirements": [
+      ["sword", 80]
+    ],
+    "mob": "mistrz Gregor",
+    "cost": 7878,
+    "chance": 21,
+    "roomVnum": 4522,
+    "notes": "1,8% przy każdym trafieniu mieczem (sword) lub krótkim mieczem (short-sword)"
+  },
+  {
+    "name": "Bleed (Short-sword",
+    "requirements": [
+      ["short-sword", 80]
+    ],
+    "mob": "mistrz Gregor",
+    "cost": 7878,
+    "chance": 21,
+    "roomVnum": 4522,
+    "notes": "1,8% przy każdym trafieniu mieczem (sword) lub krótkim mieczem (short-sword)"
+  },
+  {
+    "name": "Ravaging Orb",
+    "requirements": [
+      ["flail", 80],
+      ["twohanded weapon", 80]
+    ],
+    "mob": "stary śnieżny troll",
+    "cost": 8000,
+    "chance": 23,
+    "roomVnum": 43932,
+    "notes": "2,5% na każdą rundę walki dwuręcznym korbaczem (flail) - zamiast rundy walki uruchamia specjalny atak"
+  },
+  {
+    "name": "Crushing Mace",
+    "requirements": [
+      ["mace", 80],
+      ["mace mastery", 80]
+    ],
+    "mob": "paladyn Marteg",
+    "cost": 6543,
+    "chance": 25,
+    "roomVnum": 40325,
+    "notes": "2% przy zwykłym ciosie obuchem (mace)"
+  },
+  {
+    "name": "Thousandslayer",
+    "requirements": [
+      ["cleave", 75],
+      ["overwhelming strike", 75]
+    ],
+    "mob": "władca mroku",
+    "cost": 8765,
+    "chance": 21,
+    "roomVnum": 33073,
+    "notes": "15% przy cleave"
+  },
+  {
+    "name": "Divine Impact (Smite Good)",
+    "requirements": [
+      ["smite good", 75]
+    ],
+    "mob": "władca mroku",
+    "cost": 7240,
+    "chance": 15,
+    "roomVnum": 33073,
+    "notes": "4,8% przy smite good"
+  },
+  {
+    "name": "Divine Impact (Smite Evil)",
+    "requirements": [
+      ["smite evil", 75]
+    ],
+    "mob": "paladyn Federmel ev Kenrah",
+    "cost": 7250,
+    "chance": 15,
+    "roomVnum": 929,
+    "notes": "4,8% przy smite good"
+  }
+]

--- a/modules.json
+++ b/modules.json
@@ -36,7 +36,7 @@
     "shortDesc": "Moduł czatu (wersja testowa)"
   },
   "kbase": {
-    "version": 6,
+    "version": 7,
     "url": "https://raw.githubusercontent.com/KillerMUD-pl/MudletScripts/main/dist/kbase.zip",
     "commands": [ "lookup" ],
     "shortDesc": "Moduł informacji o świecie"


### PR DESCRIPTION
- Dodanie listy tricków i obsługę ich wyszukiwania (+lookup trick <nazwa> i +lookup trick all)
- Dodanie wyświetlania trudności (niektórych) ksiąg
- Zmiana kolejności wyświetlania 'dangerous' - jest na końcu, bo w niektórych przypadkach nakładał się na inne znaki UTF
- Nowe moby z księgami i poprawy w name mobów
- Poprawione typo w czarze u Wędrownego Maga
- Zmiana koloru wyświetlanych czarów (z white na grey)